### PR TITLE
Upgrading construct to 2.9

### DIFF
--- a/creddec.py
+++ b/creddec.py
@@ -136,8 +136,9 @@ if __name__ == '__main__':
             print '-'*79
 
             enc_cred = vaultstruct.CREDENTIAL_FILE.parse(fin.read())
+            print enc_cred
 
-            cred_blob = blob.DPAPIBlob(enc_cred.data.raw)
+            cred_blob = blob.DPAPIBlob(enc_cred.blob)
 
             if umkp:
                 dec_cred, res_err = decrypt_blob(umkp, cred_blob)

--- a/vaultstruct.py
+++ b/vaultstruct.py
@@ -19,30 +19,22 @@
 # vault structs are a mix of my research and his research.
 """Windows Vaults structures."""
 
-import construct
+from construct import *
 import datetime
 import pytz
 
 
-# Construct adapters.
+#===============================================================================
+#                   Adapters -  Make the output more human readable
+#===============================================================================
 
-class GuidAdapter(construct.Adapter):
-    def _decode(self, obj, context):
-        return '{:08x}-{:04x}-{:04x}-{:04x}-{:s}'.format(
-            construct.ULInt32('foo').parse(obj[0:4]),
-            construct.ULInt16('foo').parse(obj[4:6]),
-            construct.ULInt16('foo').parse(obj[6:8]),
-            construct.UBInt16('foo').parse(obj[8:10]),
-            obj[10:16].encode('hex'))
+class GuidAdapter(Adapter):
+    def _decode(self, guid, context, path):
+        return '{data1:x}-{data2:x}-{data3:x}-{data4}-{data5}'.format(data1=guid.data1, data2=guid.data2, data3=guid.data3, data4=guid.data4.encode('hex')[:4], data5=guid.data4.encode('hex')[4:])
 
-
-def GUID(name):
-    return GuidAdapter(construct.Bytes(name, 16))
-
-
-class FileTimeAdapter(construct.Adapter):
+class FileTimeAdapter(Adapter):
     '''Adapted from Rekall Memory Forensics code.'''
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         unix_time = obj / 10000000 - 11644473600
         if unix_time < 0:
             unix_time = 0
@@ -53,303 +45,254 @@ class FileTimeAdapter(construct.Adapter):
         return dt.isoformat()
 
 
-def FILETIME(name):
-    return FileTimeAdapter(construct.ULInt64(name))
+#===============================================================================
+#                               Common structs.
+#===============================================================================
 
-
-# Common structs.
-
-UNICODE_STRING = construct.Struct(
-    'UNICODE_STRING',
-    construct.ULInt32('length'),
-    construct.String('data', lambda ctx: ctx.length, encoding='utf16'))
-
-
-SIZED_DATA = construct.Struct(
-    'SIZED_DATA',
-    construct.ULInt32('size'),
-    construct.Bytes('data', lambda ctx: ctx.size)
+UNICODE_STRING = Struct(
+    'length'    / Int32ul,
+    'data'      / String(this.length, encoding='UTF_16_LE'),
 )
+
+SIZED_DATA = Struct(
+    'size'  / Int32ul,
+    'data'  / Bytes(this.size)
+)
+
+GUID = Struct(
+    'data1' / Int32ul,
+    'data2' / Int16ul,
+    'data3' / Int16ul,
+    'data4' / Bytes(8),
+)
+
+#===============================================================================
+#                               DPAPI Blob
+#===============================================================================
 
 # DPAPI structs.
 
-DPAPI_BLOB = construct.Struct(
-    'BLOB',
-    construct.ULInt32('version'),
-    GUID('provider'),
-    construct.ULInt32('mk_version'),
-    GUID('mk_guid'),
-    construct.ULInt32('flags'),
-    construct.Rename('description', UNICODE_STRING),
-    construct.ULInt32('crypt_alg_id'),
-    construct.ULInt32('crypt_alg_len'),
-    construct.ULInt32('salt_len'),
-    construct.Bytes('salt', lambda ctx: ctx.salt_len),
-    construct.ULInt32('unknown1'),
-    construct.ULInt32('hash_alg_id'),
-    construct.ULInt32('hash_alg_len'),
-    construct.ULInt32('hmac_len'),
-    construct.Bytes('hmac', lambda ctx: ctx.hmac_len),
-    construct.ULInt32('encrypted_len'),
-    construct.Bytes('encrypted', lambda ctx: ctx.encrypted_len),
-    construct.ULInt32('sign_len'),
-    construct.Bytes('sign', lambda ctx: ctx.sign_len)
+DPAPI_BLOB = Struct(
+    'mkversion'     / Int32ul,
+    'mkblob'        / GUID,
+    'flags'         / Int32ul, 
+    'description'   / UNICODE_STRING,
+    'cipherAlgo'    / Int32ul, 
+    'keyLen'        / Int32ul, 
+    'salt'          / SIZED_DATA,
+    'strong'        / SIZED_DATA,
+    'hashAlgo'      / Int32ul, 
+    'hashLen'       / Int32ul, 
+    'hmac'          / SIZED_DATA,
+    'cipherText'    / SIZED_DATA,
 )
 
-DPAPI_BLOB_STORE = construct.Struct(
-    'DPAPI_BLOB_STORE',
-    construct.ULInt32('size'),
-    construct.Embed(
-        construct.Union(
-            '',
-            construct.Bytes('raw', lambda ctx: ctx.size),
-            construct.Rename('blob', DPAPI_BLOB)
-        )
-    )
+DPAPI_BLOB_STRUCT = Struct(
+    'version'   / Int32ul,
+    # 'provider'    / GuidAdapter(GUID),
+    'provider'  / GUID,
+    'blob'      / DPAPI_BLOB,
+    'sign'      / SIZED_DATA,       # For HMAC computation
 )
 
-# VAULT POLICY file structs.
-
-VAULT_POL_STORE = construct.Struct(
-    'VAULT_POL_STORE',
-    construct.ULInt32('size'),
-    construct.Embed(
-        construct.Union(
-            '',
-            construct.Bytes('raw', lambda ctx: ctx.size),
-            construct.Embed(
-                construct.Struct(
-                    '',
-                    GUID('unknown1'),
-                    GUID('unknown2'),
-                    construct.Rename('blob_store', DPAPI_BLOB_STORE)
-                )
-            )
-        )
-    )
+DPAPI_BLOB_STORE = Struct(
+    'size'  / Int32ul,
+    'raw'   / DPAPI_BLOB_STRUCT, 
 )
 
-VAULT_POL = construct.Struct(
-    'VAULT_POL',
-    construct.ULInt32('version'),
-    GUID('guid'),
-    construct.Rename('description', UNICODE_STRING),
-    construct.ULInt32('unknown1'),
-    construct.ULInt32('unknown2'),
-    construct.ULInt32('unknown3'),
-    construct.Rename('vpol_store', VAULT_POL_STORE)
-)
+#===============================================================================
+#                           Credential Files structs.
+#===============================================================================
 
-# Key Data Blob Magic (KDBM).
-BCRYPT_KEY_DATA_BLOB_HEADER = construct.Struct(
-    'BCRYPT_KEY_DATA_BLOB_HEADER',
-    construct.Const(construct.ULInt32('dwMagic'), 0x4d42444b),
-    construct.ULInt32('dwVersion'),
-    construct.ULInt32('cbKeyData')
-)
-
-BCRYPT_KEY_DATA_BLOB = construct.Struct(
-    'BCRYPT_KEY_DATA_BLOB',
-    construct.Embed(BCRYPT_KEY_DATA_BLOB_HEADER),
-    construct.Bytes('key', lambda ctx: ctx.cbKeyData)
-)
-
-BCRYPT_KEY_STORE = construct.Struct(
-    'BCRYPT_KEY_STORE',
-    construct.ULInt32('size'),
-    construct.Embed(
-        construct.Union(
-            '',
-            construct.Bytes('raw', lambda ctx: ctx.size),
-            construct.Embed(
-                construct.Struct(
-                    '',
-                    construct.ULInt32('unknown1'),
-                    construct.ULInt32('unknown2'),
-                    construct.Rename('bcrypt_blob', BCRYPT_KEY_DATA_BLOB)
-                )
-            )
-        )
-    )
-)
-
-VAULT_POL_KEYS = construct.Struct(
-    'VAULT_POL_KEYS',
-    construct.Rename('vpol_key1', BCRYPT_KEY_STORE),
-    construct.Rename('vpol_key2', BCRYPT_KEY_STORE)
-)
 
 # CREDENTIALS file structs.
 
-CREDENTIAL_FILE = construct.Struct(
-    'CREDENTIAL_FILE',
-    construct.ULInt32('unknown1'),
-    construct.ULInt32('blob_size'),
-    construct.ULInt32('unknown2'),
-    construct.Union(
-        'data',
-        construct.Bytes('raw', lambda ctx: ctx._.blob_size),
-        construct.Rename('blob', DPAPI_BLOB)
-    )
+CREDENTIAL_FILE = Struct(
+    'unknown1'  / Int32ul, 
+    'blob_size' / Int32ul, 
+    'unknown2'  / Int32ul, 
+    'blob'      / Bytes(this.blob_size),
 )
 
-CREDENTIAL_DEC_HEADER = construct.Struct(
-    'CREDENTIAL_DEC_HEADER',
-    construct.ULInt32('header_size'),
-    construct.Embed(
-        construct.Union(
-            '',
-            construct.Bytes('raw', lambda ctx: ctx.header_size - 4),
-            construct.Embed(
-                construct.Struct(
-                    '',
-                    construct.ULInt32('total_size'),
-                    construct.ULInt32('unknown1'),
-                    construct.ULInt32('unknown2'),
-                    construct.ULInt32('unknown3'),
-                    FILETIME('last_update'),
-                    construct.ULInt32('unknown4'),
-                    construct.ULInt32('unk_type'),
-                    construct.ULInt32('unk_blocks'),
-                    construct.ULInt32('unknown5'),
-                    construct.ULInt32('unknown6')
+CREDENTIAL_DEC_HEADER = Struct(
+    'header_size'   / Int32ul,
+    Embedded(
+        Union(  
+            this.header_size - 4,
+            Embedded(
+                Struct(
+                    'total_size'    / Int32ul,
+                    'unknown1'      / Int32ul,
+                    'unknown2'      / Int32ul,
+                    'unknown3'      / Int32ul,
+                    'last_update'   / FileTimeAdapter(Int64ul),
+                    'unknown4'      / Int32ul,
+                    'unk_type'      / Int32ul,
+                    'unk_blocks'    / Int32ul,
+                    'unknown5'      / Int32ul,
+                    'unknown6'      / Int32ul,
                 )
             )
         )
     )
 )
 
-CREDENTIAL_DEC_MAIN = construct.Struct(
-    'CREDENTIAL_DEC_MAIN',
-    construct.Rename('domain', UNICODE_STRING),
-    construct.Rename('unk_string1', UNICODE_STRING),
-    construct.Rename('unk_string2', UNICODE_STRING),
-    construct.Rename('unk_string3', UNICODE_STRING),
-    construct.Rename('username', UNICODE_STRING),
-    construct.Rename('password', UNICODE_STRING)
+# Once the blob decrypted, we got a new structure
+
+CREDENTIAL_DEC_MAIN = Struct(
+    'domain'        / UNICODE_STRING, 
+    'unk_string1'   / UNICODE_STRING, 
+    'unk_string2'   / UNICODE_STRING, 
+    'unk_string3'   / UNICODE_STRING, 
+    'username'      / UNICODE_STRING, 
+    'password'      / UNICODE_STRING, 
 )
 
-'''
-CREDENTIAL_DEC_BLOCK_ENC = construct.Struct(
-    'CREDENTIAL_DEC_BLOCK_ENC',
-    construct.ULInt32('empty'),
-    construct.Rename('block_name', UNICODE_STRING),
-    construct.Anchor('position'),
-    construct.Padding(lambda ctx: 16 - ctx.position % 16),
-    construct.Rename('description', UNICODE_STRING),
-    construct.ULInt32('size'),
-    construct.Bytes('raw_data', lambda ctx: ctx.size)
+CREDENTIAL_DEC_BLOCK_ENC = Struct(
+    'empty'         / Int32ul, 
+    'block_name'    / UNICODE_STRING, 
+    'size'          / Int32ul, 
+    'raw_data'      / Bytes(this.size)
 )
-'''
 
-CREDENTIAL_DEC_BLOCK_ENC = construct.Struct(
-    'CREDENTIAL_DEC_BLOCK_ENC',
-    construct.ULInt32('empty'),
-    construct.Rename('block_name', UNICODE_STRING),
-    construct.ULInt32('size'),
-    construct.Bytes('raw_data', lambda ctx: ctx.size)
+CREDENTIAL_DECRYPTED = Struct(
+    'header'    / CREDENTIAL_DEC_HEADER, 
+    'main'      / CREDENTIAL_DEC_MAIN, 
+    # 'data'        / If(this.header.unk_type == 2, Array(this.header.unk_blocks, CREDENTIAL_DEC_BLOCK_ENC))
 )
 
 
-CREDENTIAL_DECRYPTED = construct.Struct(
-    'CREDENTIAL_DECRYPTED',
-    construct.Rename('header', CREDENTIAL_DEC_HEADER),
-    construct.Rename('main', CREDENTIAL_DEC_MAIN),
-    construct.If(
-        lambda ctx: ctx.header.unk_type == 2,
-        construct.Array(
-            lambda ctx: ctx.header.unk_blocks,
-            CREDENTIAL_DEC_BLOCK_ENC
+#===============================================================================
+#                           VAULT POLICY file structs
+#===============================================================================
+
+
+# VAULT POLICY file structs.
+
+VAULT_POL_STORE = Struct(
+    'size' / Int32ul,
+    Embedded(
+        Union(  
+            this.size, 
+            Embedded(
+                Struct(
+                    'unknown1'      / GuidAdapter(GUID),
+                    'unknown2'      / GuidAdapter(GUID),
+                    'blob_store'    / DPAPI_BLOB_STORE, 
+                )
+            )
         )
     )
 )
+
+VAULT_POL = Struct(
+    'version'       / Int32ul,
+    'guid'          / GuidAdapter(GUID), 
+    'description'   / UNICODE_STRING,
+    'unknown1'      / Int32ul,
+    'unknown2'      / Int32ul,
+    'unknown3'      / Int32ul,
+    'vpol_store'    / VAULT_POL_STORE,
+)
+
+
+# Key Data Blob Magic (KDBM).
+BCRYPT_KEY_DATA_BLOB = Struct(
+    'dwMagic'       / Const(0x4d42444b, Int32ul), 
+    'dwVersion'     / Int32ul,
+    'cbKeyData'     / Int32ul,
+    'key'           / Bytes(this.cbKeyData)
+)
+
+BCRYPT_KEY_STORE = Struct(
+    'size' / Int32ul,
+    Embedded(
+        Union(  
+            this.size, 
+            Embedded(
+                Struct(
+                        'unknown1'      / Int32ul,
+                        'unknown2'      / Int32ul,
+                        'bcrypt_blob'   / BCRYPT_KEY_DATA_BLOB, 
+                )
+            )
+        )
+    )
+)
+
+VAULT_POL_KEYS = Struct(
+    'vpol_key1' / BCRYPT_KEY_STORE, 
+    'vpol_key2' / BCRYPT_KEY_STORE,
+)
+
+
+#===============================================================================
+#                               VAULT file structs 
+#===============================================================================
 
 # VAULT file structs.
 
-VAULT_ATTRIBUTE_ENCRYPTED = construct.Struct(
-    'VAULT_ATTRIBUTE_ENCRYPTED',
-    construct.Byte('has_iv'),
-    construct.IfThenElse(
-        '',
-        lambda ctx: ctx.has_iv,
-        construct.Embed(
-            construct.Struct(
-                'encrypted',
-                construct.ULInt32('iv_size'),
-                construct.Bytes('iv', lambda ctx: ctx.iv_size),
-                construct.Bytes(
-                    'data',
-                    lambda ctx: ctx.size - 1 - 4 - ctx.iv_size
-                )
-            )
+VAULT_ATTRIBUTE_ENCRYPTED = Struct(
+    'has_iv'    / Byte,
+    'encrypted' / IfThenElse(this.has_iv == 1,
+        Embedded(
+            Struct( 
+                'iv_size'   / Int32ul,
+                'iv'        / Bytes(this.iv_size), 
+                'data'      / Bytes(this._._.size - 1 - 4 - this.iv_size),
+            ),
         ),
-        construct.Embed(
-            construct.Struct(
-                'encrypted',     
-                construct.Bytes('data', lambda ctx: ctx.size-1)
-            )
-        )
+        Embedded(
+            Struct( 
+                'data'      / Bytes(this._._.size - 1),
+            ),
+        ),
     )
 )
 
-VAULT_ATTRIBUTE = construct.Struct(
-    'VAULT_ATTRIBUTE',
-	construct.ULInt32('id'),
-    construct.ULInt32('attr_unknown_1'),
-    construct.ULInt32('attr_unknown_2'),
-    construct.ULInt32('attr_unknown_3'),
+VAULT_ATTRIBUTE = Struct(
+    'id'                    / Int32ul, 
+    'attr_unknown_1'        / Int32ul, 
+    'attr_unknown_2'        / Int32ul, 
+    'attr_unknown_3'        / Int32ul, 
     # Ok, this is bad, but till now I have not understood how to distinguish
     # the different structs used. Actually the last ATTRIBUTE is different.
     # Usually we have 6 more bytes zeroed, not always aligned: otherwise,
     # if id >= 100, we have 4 more bytes: weird.
-    construct.Optional(
-        construct.Const(construct.Bytes('padding', 6), '\x00'*6)),
-    construct.If(
-        lambda ctx: not ctx.padding and ctx.id >= 0x64,
-        construct.ULInt32('attr_unknown_4')
-    ),
-    construct.ULInt32('size'),
-    construct.If(
-        lambda ctx: ctx.size > 0,
-        construct.Embed(VAULT_ATTRIBUTE_ENCRYPTED)),
-    construct.Anchor('stream_end')
+    'padding'               / Optional(Const('\x00'*6, Bytes(6))),
+    'attr_unknown_4'        / If(this.id >= 100, Int32ul),
+    'size'                  / Int32ul,
+    'vault_attr_encrypted'  / If(this.size > 0, VAULT_ATTRIBUTE_ENCRYPTED),
+    'stream_end'            / Tell,
 )
 
-VAULT_ATTRIBUTE_EXTRA = construct.Struct(
-    'VAULT_ATTRIBUTE_EXTRA',
-	construct.ULInt32('id'),
-    construct.ULInt32('attr_unknown_1'),
-    construct.ULInt32('attr_unknown_2'),
-    construct.Embed(SIZED_DATA)
+VAULT_ATTRIBUTE_EXTRA = Struct(
+    'id'                / Int32ul, 
+    'attr_unknown_1'    / Int32ul, 
+    'attr_unknown_2'    / Int32ul, 
+    'data'              / SIZED_DATA,
 )
 
-VAULT_ATTRIBUTE_MAP_ENTRY = construct.Struct(
-    'VAULT_ATTRIBUTE_MAP_ENTRY',
-    construct.ULInt32('id'),
-    construct.ULInt32('offset'),
-    construct.ULInt32('attr_map_entry_unknown_1'),
-    construct.Pointer(lambda ctx: ctx.offset, VAULT_ATTRIBUTE)
+VAULT_ATTRIBUTE_MAP_ENTRY = Struct(
+    'id'                        / Int32ul, 
+    'offset'                    / Int32ul, 
+    'attr_map_entry_unknown_1'  / Int32ul,
+    'pointer'                   / Pointer(this.offset, VAULT_ATTRIBUTE),
 )
 
-VAULT_VCRD = construct.Struct(
-    'VAULT_VCRD',
-    GUID('schema_guid'),
-    construct.ULInt32('vcrd_unknown_1'),
-    FILETIME('last_update'),
-    construct.ULInt32('vcrd_unknown_2'),
-    construct.ULInt32('vcrd_unknown_3'),
-    construct.Rename('description', UNICODE_STRING),
-    construct.ULInt32('attributes_array_size'),
-    construct.Value(
-        'attributes_num',
-        lambda ctx: (
-            ctx.attributes_array_size / VAULT_ATTRIBUTE_MAP_ENTRY.sizeof())),
-    construct.Rename(
-        'attributes',
-        construct.Array(
-            lambda ctx: ctx.attributes_num, VAULT_ATTRIBUTE_MAP_ENTRY)),
-    construct.Pointer(
-        lambda ctx: (
-            ctx.attributes[ctx.attributes_num-1].VAULT_ATTRIBUTE.stream_end),
-        construct.Rename('extra_entry', VAULT_ATTRIBUTE_EXTRA))
+VAULT_VCRD = Struct(
+    'schema_guid'           / GuidAdapter(GUID),
+    'vcrd_unknown_1'        / Int32ul, 
+    'last_update'           / FileTimeAdapter(Int64ul),
+    'vcrd_unknown_2'        / Int32ul, 
+    'vcrd_unknown_3'        / Int32ul, 
+    'description'           / UNICODE_STRING, 
+    'attributes_array_size' / Int32ul,
+    # 12 is the size of the VAULT_ATTRIBUTE_MAP_ENTRY structure => VAULT_ATTRIBUTE_MAP_ENTRY.sizeof() fails because of the pointer field
+    'attributes_num'        / Computed(this.attributes_array_size / 12),
+    'attributes'            / Array(this.attributes_num,  VAULT_ATTRIBUTE_MAP_ENTRY),
+    'extra_entry'           / Pointer(
+                                lambda ctx: (ctx.attributes[ctx.attributes_num -1].pointer.stream_end), 
+                                VAULT_ATTRIBUTE_EXTRA
+                            ),
 )


### PR DESCRIPTION
Construct has changed its [synthax](http://construct.readthedocs.io/en/latest/transition29.html). For my projects, I needed to upgrade this lib to the new version so as I did it for me, I shared it with you, maybe it could be useful. 

You did a great work concerning Windows file parsing. Thanks for it. 

I have a question that I cannot answer about the CREDHIST file and maybe you could help me. I found this definition: 
_"When a user's password changes, or 90 days have passed (whichever is sooner) a new set of keys are generated. The old ones are kept in the CREDHIST file so that applications can still decrypt files that were encrypted using the older keys. When an application asks DPAPI to decrypt something, it will first try with the current master key (this is contained in the 'Preferred' file, which you'll find in the \..\protect\<User GUID> folder) - if that fails it will try each of the CREDHIST keys in turn until the data are successfully decrypted."_

However, doing some tests I not agree with that definition. I agree that CREDHIST file really store previous keys. However, when I changed my windows password, I'm able to decrypt all masterkey files without needed to retrieve keys stored on the CREDHIST file. It's like, Windows encrypt again all masterkey files with the new. Keys stored on these masterkey files don't change, only the password used to encrypt the file. 

I have done my tests only on a Windows 10 host so maybe the behaviour has changed. 

Maybe you could help me to understand, what's the goal of this file. 

Thanks a lot. Have a nice day. 

